### PR TITLE
fix classname detection for RL on Linux

### DIFF
--- a/RemoteInput/Platform/Platform_Linux.cxx
+++ b/RemoteInput/Platform/Platform_Linux.cxx
@@ -433,7 +433,7 @@ void* GetModuleHandle(const char* module_name) noexcept
 #endif
 
 #if defined(__linux__)
-std::vector<std::string> recognizedClassNames = {
+std::array<std::string, 2> recognizedClassNames = {
     "jagexappletviewer",  // Jagex client
     "net-runelite-client-RuneLite",  // RuneLite client
 };

--- a/RemoteInput/Platform/Platform_Linux.cxx
+++ b/RemoteInput/Platform/Platform_Linux.cxx
@@ -441,18 +441,21 @@ bool EnumWindowsProc(Display* display, Window window, void* other) noexcept
 {
     pid_t pid = 0;
     GetWindowThreadProcessId(display, window, &pid);
-    if (pid != getpid() || other == nullptr) {
+    if (pid != getpid() || other == nullptr)
+    {
         // wrong process ID, or a null `other` parameter:
         return true;
     }
     char className[256] = {0};
-    if (GetClassName(display, window, className, sizeof(className)) > 0) {
+    if (GetClassName(display, window, className, sizeof(className)) > 0)
+    {
         const auto matchedClassName = std::find(
             std::begin(recognizedClassNames),
             std::end(recognizedClassNames),
             std::string(className)
         );
-        if (matchedClassName != std::end(recognizedClassNames)) {
+        if (matchedClassName != std::end(recognizedClassNames))
+        {
             // the correct window has been located, so assign this `Window`
             // object to the `other` parameter, and return false to
             // indicate that the operation was a success.

--- a/RemoteInput/Platform/Platform_Linux.cxx
+++ b/RemoteInput/Platform/Platform_Linux.cxx
@@ -433,19 +433,35 @@ void* GetModuleHandle(const char* module_name) noexcept
 #endif
 
 #if defined(__linux__)
+std::vector<std::string> recognizedClassNames = {
+    "jagexappletviewer",  // Jagex client
+    "net-runelite-client-RuneLite",  // RuneLite client
+};
 bool EnumWindowsProc(Display* display, Window window, void* other) noexcept
 {
     pid_t pid = 0;
     GetWindowThreadProcessId(display, window, &pid);
-    if (pid == getpid() && other)
-    {
-        char className[256] = {0};
-        int result = GetClassName(display, window, className, sizeof(className));
-        if (result != 0 && std::string(className) == "jagexappletviewer")  //Need a better way to check the class..
-        {
+    if (pid != getpid() || other == nullptr) {
+        // wrong process ID, or a null `other` parameter:
+        return true;
+    }
+    char className[256] = {0};
+    if (GetClassName(display, window, className, sizeof(className)) > 0) {
+        const auto matchedClassName = std::find(
+            std::begin(recognizedClassNames),
+            std::end(recognizedClassNames),
+            std::string(className)
+        );
+        if (matchedClassName != std::end(recognizedClassNames)) {
+            // the correct window has been located, so assign this `Window`
+            // object to the `other` parameter, and return false to
+            // indicate that the operation was a success.
             *reinterpret_cast<Window*>(other) = window;
             return false;
         }
+        #if defined(DEBUG)
+        printf("excluded window with class name '%s'\n", className);
+        #endif
     }
     return true;
 }


### PR DESCRIPTION
Since some point in the past, RL's "main" window uses a different classname than the one used by the official client. This seems to only be the case on Linux. I am using Void Linux with `openjdk17-jre`.

I am advised that the reflection code is likely not working on RL, but from some adhoc testing this fixes the plugin sufficiently that painting, keyboard and mouse operations work as intended.

Changes:
- rework `Platform_Linux.cxx:EnumWindowsProc` to detect both classnames that might be used between OS client and RL. It should now be a bit more maintainable.

![image](https://user-images.githubusercontent.com/78256408/190874918-b61d36ba-ed53-4019-873d-1fe3885e4bcc.png)
